### PR TITLE
switched from go-ns/rchttp to dp-rchttp

### DIFF
--- a/auth/permissions_client.go
+++ b/auth/permissions_client.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/ONSdigital/go-ns/rchttp"
+	"github.com/ONSdigital/dp-rchttp"
 )
 
 const (


### PR DESCRIPTION
Updated client to switch from `go-ns/rchttp` to use `dp-rchttp` library for the http.client.