### PR TITLE
Deprecated LogNamespace func as this is overwriting the app namespace…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
-build-example:
+example:
 	go build -o ./example/example example/main.go
-
-debug-example:
 	go run -race example/main.go
 
 test:
@@ -10,4 +8,4 @@ test:
 clean:
 	rm example/example
 
-.PHONY: build test clean
+.PHONY: example test clean

--- a/auth/handler.go
+++ b/auth/handler.go
@@ -42,9 +42,10 @@ type Handler struct {
 	permissionsVerifier Verifier
 }
 
-// LoggerNamespace set the log namespace for auth package logging.
+// LoggerNamespace Deprecated. Do not set a separate namespace for the library by default it will use the namespace configured by the app.
 func LoggerNamespace(logNamespace string) {
-	log.Namespace = logNamespace
+	// Deprecated - log package is single threaded and cannot support multiple namespaces concurrently.
+	// Don't use this function anymore - the app namespace will be used for all auth log events.
 }
 
 // NewHandler construct a new Handler.

--- a/example/main.go
+++ b/example/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"fmt"
+	"context"
 	"net/http"
 
 	"github.com/ONSdigital/dp-authorisation/auth"
+	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
 )
 
@@ -13,8 +14,8 @@ var (
 )
 
 func main() {
-	// Set the auth package log namespace.
-	auth.LoggerNamespace("<application-name>-auth")
+	// Set the log namespace.
+	log.Namespace = "example-api"
 
 	// GetPermissionsRequestBuilder for authorising access to datasets.
 	datasetPermissionsRequestBuilder := auth.NewDatasetPermissionsRequestBuilder("http://localhost:8082", "dataset_id", mux.Vars)
@@ -38,7 +39,7 @@ func main() {
 	router.HandleFunc("/datasets", permissions.Require(read, getDatasetsHandlerFunc)).Methods("GET")
 	router.HandleFunc("/datasets/{dataset_id}", datasetsPermissions.Require(read, getDatasetHandlerFunc)).Methods("GET")
 
-	fmt.Println("starting server")
+	log.Event(context.Background(), "starting dp-authorisation example API", log.INFO)
 	err := http.ListenAndServe(":22000", router)
 	if err != nil {
 		panic(err)
@@ -47,12 +48,13 @@ func main() {
 
 // an example http.HandlerFunc for getting a dataset
 func getDatasetsHandlerFunc(w http.ResponseWriter, r *http.Request) {
+	log.Event(r.Context(), "get datasets stub invoked", log.INFO)
 	w.Write([]byte("datasets info here"))
 }
 
 // an example http.HandlerFunc for getting a dataset
 func getDatasetHandlerFunc(w http.ResponseWriter, r *http.Request) {
 	datasetID := mux.Vars(r)["dataset_id"]
-	fmt.Printf("dataset %s: info here", datasetID)
+	log.Event(r.Context(), "get dataset stub invoked", log.INFO, log.Data{"dataset_id": datasetID})
 	w.Write([]byte("dataset info here"))
 }


### PR DESCRIPTION
Deprecated` LogNamespace` func as this is overwriting the app namespace.

Our log library is single threaded and cannot support multiple concurrent namespaces. Setting a namespace for the auth lib overwrites any previously set app namespace. As a result any app logs are collated under a different namespace in Kibana.

The proper fix for this might need to be a v2 release as it technically breaks backwards compatability.