### PR TITLE
replace go fmt with noop in make lint rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ build:
 .PHONY: build
 
 lint:
-	go fmt ./...
+	exit
 .PHONY: lint


### PR DESCRIPTION
go fmt added in error as operation for make lint rule.
Pending decision on linters this should be left as noop
for the time being.