### PR TITLE
Align permissions bundle model with permissions API

### DIFF
--- a/v2/permissions/api_client.go
+++ b/v2/permissions/api_client.go
@@ -32,7 +32,7 @@ func NewAPIClient(host string, httpClient HTTPClient) *APIClient {
 }
 
 // GetPermissionsBundle gets the permissions bundle data from the permissions API.
-func (c *APIClient) GetPermissionsBundle(ctx context.Context) (*Bundle, error) {
+func (c *APIClient) GetPermissionsBundle(ctx context.Context) (Bundle, error) {
 
 	uri := fmt.Sprintf("%s/v1/permissions-bundle", c.host)
 
@@ -63,13 +63,13 @@ func (c *APIClient) GetPermissionsBundle(ctx context.Context) (*Bundle, error) {
 	return permissions, nil
 }
 
-func getPermissionsBundleFromResponse(reader io.Reader) (*Bundle, error) {
+func getPermissionsBundleFromResponse(reader io.Reader) (Bundle, error) {
 	b, err := getResponseBytes(reader)
 	if err != nil {
 		return nil, err
 	}
 
-	var bundle *Bundle
+	var bundle Bundle
 
 	if err := json.Unmarshal(b, &bundle); err != nil {
 		return nil, ErrFailedToParsePermissionsResponse

--- a/v2/permissions/api_client_test.go
+++ b/v2/permissions/api_client_test.go
@@ -42,11 +42,11 @@ func TestAPIClient_GetPermissionsBundle(t *testing.T) {
 			Convey("Then the expected permissions bundle is returned", func() {
 				So(bundle, ShouldNotBeNil)
 
-				policies := bundle.PermissionToEntityLookup["permission/admin"]["group/admin"]
+				policies := bundle["permission/admin"]["group/admin"]
 				So(policies, ShouldHaveLength, 1)
 
 				policy := policies[0]
-				So(policy.PolicyID, ShouldEqual, "policy/123")
+				So(policy.ID, ShouldEqual, "policy/123")
 				So(policy.Conditions[0].Attributes, ShouldHaveLength, 1)
 				So(policy.Conditions[0].Attributes[0], ShouldEqual, "collection_id")
 				So(policy.Conditions[0].Operator, ShouldEqual, "equals")
@@ -180,17 +180,15 @@ func getExampleBundleJson() []byte {
 func getExampleBundle() permissions.Bundle {
 
 	bundle := permissions.Bundle{
-		PermissionToEntityLookup: permissions.PermissionToEntityLookup{
-			"permission/admin": map[string][]permissions.Policy{
-				"group/admin": {
-					{
-						PolicyID: "policy/123",
-						Conditions: []permissions.Condition{
-							{
-								Attributes: []string{"collection_id"},
-								Operator:   "equals",
-								Values:     []string{"col123"}},
-						},
+		"permission/admin": map[string][]permissions.Policy{
+			"group/admin": {
+				{
+					ID: "policy/123",
+					Conditions: []permissions.Condition{
+						{
+							Attributes: []string{"collection_id"},
+							Operator:   "equals",
+							Values:     []string{"col123"}},
 					},
 				},
 			},

--- a/v2/permissions/cache.go
+++ b/v2/permissions/cache.go
@@ -14,7 +14,7 @@ var _ Store = (*CachingStore)(nil)
 // CachingStore is a permissions store implementation that caches permission data in memory.
 type CachingStore struct {
 	underlyingStore      Store
-	cachedBundle         *Bundle
+	cachedBundle         Bundle
 	closing              chan struct{}
 	expiryCheckerClosed  chan struct{}
 	cacheUpdaterClosed   chan struct{}
@@ -34,7 +34,7 @@ func NewCachingStore(underlyingStore Store) *CachingStore {
 }
 
 // GetPermissionsBundle returns the cached permission data, or an error if it's not cached.
-func (c *CachingStore) GetPermissionsBundle(ctx context.Context) (*Bundle, error) {
+func (c *CachingStore) GetPermissionsBundle(ctx context.Context) (Bundle, error) {
 	if c.cachedBundle == nil {
 		return nil, ErrNotCached
 	}
@@ -43,7 +43,7 @@ func (c *CachingStore) GetPermissionsBundle(ctx context.Context) (*Bundle, error
 }
 
 // Update the permissions cache data, by calling the underlying permissions store
-func (c *CachingStore) Update(ctx context.Context) (*Bundle, error) {
+func (c *CachingStore) Update(ctx context.Context) (Bundle, error) {
 	bundle, err := c.underlyingStore.GetPermissionsBundle(ctx)
 
 	c.mutex.Lock()

--- a/v2/permissions/cache_test.go
+++ b/v2/permissions/cache_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func TestCachingStore_Update(t *testing.T) {
-	expectedBundle := &permissions.Bundle{}
+	expectedBundle := permissions.Bundle{}
 	ctx := context.Background()
 	underlyingStore := &mock.StoreMock{
-		GetPermissionsBundleFunc: func(ctx context.Context) (*permissions.Bundle, error) {
+		GetPermissionsBundleFunc: func(ctx context.Context) (permissions.Bundle, error) {
 			return expectedBundle, nil
 		},
 	}
@@ -41,7 +41,7 @@ func TestCachingStore_Update_UnderlyingStoreErr(t *testing.T) {
 	expectedErr := errors.New("API broke")
 	ctx := context.Background()
 	underlyingStore := &mock.StoreMock{
-		GetPermissionsBundleFunc: func(ctx context.Context) (*permissions.Bundle, error) {
+		GetPermissionsBundleFunc: func(ctx context.Context) (permissions.Bundle, error) {
 			return nil, expectedErr
 		},
 	}
@@ -64,10 +64,10 @@ func TestCachingStore_Update_UnderlyingStoreErr(t *testing.T) {
 }
 
 func TestCachingStore_GetPermissionsBundle(t *testing.T) {
-	expectedBundle := &permissions.Bundle{}
+	expectedBundle := permissions.Bundle{}
 	ctx := context.Background()
 	underlyingStore := &mock.StoreMock{
-		GetPermissionsBundleFunc: func(ctx context.Context) (*permissions.Bundle, error) {
+		GetPermissionsBundleFunc: func(ctx context.Context) (permissions.Bundle, error) {
 			return expectedBundle, nil
 		},
 	}
@@ -113,9 +113,9 @@ func TestCachingStore_GetPermissionsBundle_NotCached(t *testing.T) {
 
 func TestCachingStore_CheckCacheExpiry(t *testing.T) {
 	ctx := context.Background()
-	expectedBundle := &permissions.Bundle{}
+	expectedBundle := permissions.Bundle{}
 	underlyingStore := &mock.StoreMock{
-		GetPermissionsBundleFunc: func(ctx context.Context) (*permissions.Bundle, error) {
+		GetPermissionsBundleFunc: func(ctx context.Context) (permissions.Bundle, error) {
 			return expectedBundle, nil
 		},
 	}
@@ -138,9 +138,9 @@ func TestCachingStore_CheckCacheExpiry(t *testing.T) {
 
 func TestCachingStore_CheckCacheExpiry_Expired(t *testing.T) {
 	ctx := context.Background()
-	expectedBundle := &permissions.Bundle{}
+	expectedBundle := permissions.Bundle{}
 	underlyingStore := &mock.StoreMock{
-		GetPermissionsBundleFunc: func(ctx context.Context) (*permissions.Bundle, error) {
+		GetPermissionsBundleFunc: func(ctx context.Context) (permissions.Bundle, error) {
 			return expectedBundle, nil
 		},
 	}
@@ -206,11 +206,11 @@ func TestCachingStore_HealthCheck_Critical(t *testing.T) {
 
 func TestCachingStore_HealthCheck_OK(t *testing.T) {
 	ctx := context.Background()
-	expectedBundle := &permissions.Bundle{}
+	expectedBundle := permissions.Bundle{}
 
 	Convey("Given a CachingStore with cached data", t, func() {
 		underlyingStore := &mock.StoreMock{
-			GetPermissionsBundleFunc: func(ctx context.Context) (*permissions.Bundle, error) {
+			GetPermissionsBundleFunc: func(ctx context.Context) (permissions.Bundle, error) {
 				return expectedBundle, nil
 			},
 		}
@@ -235,13 +235,13 @@ func TestCachingStore_HealthCheck_OK(t *testing.T) {
 
 func TestCachingStore_HealthCheck_Warning(t *testing.T) {
 	ctx := context.Background()
-	expectedBundle := &permissions.Bundle{}
+	expectedBundle := permissions.Bundle{}
 
 	Convey("Given a CachingStore with cached data and a failed cache update", t, func() {
 		hasBeenCalled := false
 		expectedError := errors.New("permissions API call failed")
 		underlyingStore := &mock.StoreMock{
-			GetPermissionsBundleFunc: func(ctx context.Context) (*permissions.Bundle, error) {
+			GetPermissionsBundleFunc: func(ctx context.Context) (permissions.Bundle, error) {
 				if hasBeenCalled {
 					return nil, expectedError
 				}

--- a/v2/permissions/checker.go
+++ b/v2/permissions/checker.go
@@ -95,7 +95,7 @@ func (c Checker) hasPermission(
 		return false, err
 	}
 
-	entityLookup, ok := permissionsBundle.PermissionToEntityLookup[permission]
+	entityLookup, ok := permissionsBundle[permission]
 	if !ok {
 		log.Warn(ctx, "permission not found in permissions bundle", logData)
 		return false, nil

--- a/v2/permissions/checker_test.go
+++ b/v2/permissions/checker_test.go
@@ -9,64 +9,62 @@ import (
 	"testing"
 )
 
-var permissionsBundle = &permissions.Bundle{
-	PermissionToEntityLookup: map[string]permissions.EntityIDToPolicies{
-		"users.add": map[string][]permissions.Policy{
-			"group/admin": {
-				permissions.Policy{
-					PolicyID:   "policy1",
-					Conditions: nil,
-				},
+var permissionsBundle = permissions.Bundle{
+	"users.add": map[string][]permissions.Policy{
+		"group/admin": {
+			permissions.Policy{
+				ID:         "policy1",
+				Conditions: nil,
 			},
 		},
-		"legacy.read": map[string][]permissions.Policy{
-			"group/admin": {
-				permissions.Policy{
-					PolicyID:   "policy3",
-					Conditions: []permissions.Condition{},
-				},
+	},
+	"legacy.read": map[string][]permissions.Policy{
+		"group/admin": {
+			permissions.Policy{
+				ID:         "policy3",
+				Conditions: []permissions.Condition{},
 			},
-			"group/publisher": {
-				permissions.Policy{
-					PolicyID:   "policy4",
-					Conditions: []permissions.Condition{},
-				},
+		},
+		"group/publisher": {
+			permissions.Policy{
+				ID:         "policy4",
+				Conditions: []permissions.Condition{},
 			},
-			"group/viewer": {
-				permissions.Policy{
-					PolicyID: "policy2",
-					Conditions: []permissions.Condition{
-						{
-							Attributes: []string{"collection_id"},
-							Operator:   "=",
-							Values:     []string{"collection765"},
-						},
-						{
-							Attributes: []string{"collection_id"},
-							Operator:   "=",
-							Values:     []string{"collection766"},
-						},
-						{
-							Attributes: []string{"collection_id"},
-							Operator:   "=",
-							Values:     []string{"collection767"},
-						},
+		},
+		"group/viewer": {
+			permissions.Policy{
+				ID: "policy2",
+				Conditions: []permissions.Condition{
+					{
+						Attributes: []string{"collection_id"},
+						Operator:   "=",
+						Values:     []string{"collection765"},
+					},
+					{
+						Attributes: []string{"collection_id"},
+						Operator:   "=",
+						Values:     []string{"collection766"},
+					},
+					{
+						Attributes: []string{"collection_id"},
+						Operator:   "=",
+						Values:     []string{"collection767"},
 					},
 				},
 			},
 		},
-		"legacy.write": map[string][]permissions.Policy{
-			"group/admin": {
-				permissions.Policy{
-					PolicyID:   "policy5",
-					Conditions: []permissions.Condition{},
-				},
+	},
+	"legacy.write": map[string][]permissions.Policy{
+		"group/admin": {
+			permissions.Policy{
+				ID:         "policy5",
+				Conditions: []permissions.Condition{},
 			},
-			"group/publisher": {
-				permissions.Policy{
-					PolicyID:   "policy6",
-					Conditions: []permissions.Condition{},
-				},
+		},
+		"group/publisher": {
+			permissions.Policy{
+				ID:         "policy6",
+				Conditions: []permissions.Condition{},
 			},
 		},
 	},
@@ -265,7 +263,7 @@ func TestChecker_HealthCheck(t *testing.T) {
 
 func newMockCache() *mock.CacheMock {
 	return &mock.CacheMock{
-		GetPermissionsBundleFunc: func(ctx context.Context) (*permissions.Bundle, error) {
+		GetPermissionsBundleFunc: func(ctx context.Context) (permissions.Bundle, error) {
 			return permissionsBundle, nil
 		},
 		CloseFunc: func(ctx context.Context) error {

--- a/v2/permissions/interfaces.go
+++ b/v2/permissions/interfaces.go
@@ -11,7 +11,7 @@ import (
 // Store represents a store of permission data
 // The implementation can be a client of the permissions API, though a cache implementation can also be wrapped around it.
 type Store interface {
-	GetPermissionsBundle(ctx context.Context) (*Bundle, error)
+	GetPermissionsBundle(ctx context.Context) (Bundle, error)
 }
 
 // Cache represents a cache of permissions data.

--- a/v2/permissions/mock/cache.go
+++ b/v2/permissions/mock/cache.go
@@ -23,7 +23,7 @@ var _ permissions.Cache = &CacheMock{}
 //             CloseFunc: func(ctx context.Context) error {
 // 	               panic("mock out the Close method")
 //             },
-//             GetPermissionsBundleFunc: func(ctx context.Context) (*permissions.Bundle, error) {
+//             GetPermissionsBundleFunc: func(ctx context.Context) (permissions.Bundle, error) {
 // 	               panic("mock out the GetPermissionsBundle method")
 //             },
 //             HealthCheckFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
@@ -40,7 +40,7 @@ type CacheMock struct {
 	CloseFunc func(ctx context.Context) error
 
 	// GetPermissionsBundleFunc mocks the GetPermissionsBundle method.
-	GetPermissionsBundleFunc func(ctx context.Context) (*permissions.Bundle, error)
+	GetPermissionsBundleFunc func(ctx context.Context) (permissions.Bundle, error)
 
 	// HealthCheckFunc mocks the HealthCheck method.
 	HealthCheckFunc func(ctx context.Context, state *healthcheck.CheckState) error
@@ -102,7 +102,7 @@ func (mock *CacheMock) CloseCalls() []struct {
 }
 
 // GetPermissionsBundle calls GetPermissionsBundleFunc.
-func (mock *CacheMock) GetPermissionsBundle(ctx context.Context) (*permissions.Bundle, error) {
+func (mock *CacheMock) GetPermissionsBundle(ctx context.Context) (permissions.Bundle, error) {
 	if mock.GetPermissionsBundleFunc == nil {
 		panic("CacheMock.GetPermissionsBundleFunc: method is nil but Cache.GetPermissionsBundle was just called")
 	}

--- a/v2/permissions/mock/store.go
+++ b/v2/permissions/mock/store.go
@@ -19,7 +19,7 @@ var _ permissions.Store = &StoreMock{}
 //
 //         // make and configure a mocked permissions.Store
 //         mockedStore := &StoreMock{
-//             GetPermissionsBundleFunc: func(ctx context.Context) (*permissions.Bundle, error) {
+//             GetPermissionsBundleFunc: func(ctx context.Context) (permissions.Bundle, error) {
 // 	               panic("mock out the GetPermissionsBundle method")
 //             },
 //         }
@@ -30,7 +30,7 @@ var _ permissions.Store = &StoreMock{}
 //     }
 type StoreMock struct {
 	// GetPermissionsBundleFunc mocks the GetPermissionsBundle method.
-	GetPermissionsBundleFunc func(ctx context.Context) (*permissions.Bundle, error)
+	GetPermissionsBundleFunc func(ctx context.Context) (permissions.Bundle, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -44,7 +44,7 @@ type StoreMock struct {
 }
 
 // GetPermissionsBundle calls GetPermissionsBundleFunc.
-func (mock *StoreMock) GetPermissionsBundle(ctx context.Context) (*permissions.Bundle, error) {
+func (mock *StoreMock) GetPermissionsBundle(ctx context.Context) (permissions.Bundle, error) {
 	if mock.GetPermissionsBundleFunc == nil {
 		panic("StoreMock.GetPermissionsBundleFunc: method is nil but Store.GetPermissionsBundle was just called")
 	}

--- a/v2/permissions/model.go
+++ b/v2/permissions/model.go
@@ -3,17 +3,12 @@ package permissions
 // EntityIDToPolicies maps an entity ID to a slice of policies.
 type EntityIDToPolicies map[string][]Policy
 
-// PermissionToEntityLookup maps a permission ID to the next level in the lookup table - the EntityIDToPolicies map.
-type PermissionToEntityLookup map[string]EntityIDToPolicies
-
 // Bundle is the optimised lookup table for permissions.
-type Bundle struct {
-	PermissionToEntityLookup
-}
+type Bundle map[string]EntityIDToPolicies
 
 // Policy is the policy model as stored in the permissions API.
 type Policy struct {
-	PolicyID   string      `json:"policy_id"`
+	ID         string      `json:"id"`
 	Conditions []Condition `json:"conditions"`
 }
 


### PR DESCRIPTION
- Change bundle type from a struct to a map, removing the PermissionToEntityLookup property. The bundle type is no longer explicitly declared as a pointer, as it is now a map which is already a reference type.