### PR TITLE
Add exponential backoff to GetPermissionsBundle().

### DIFF
--- a/v2/permissions/api_client.go
+++ b/v2/permissions/api_client.go
@@ -3,10 +3,20 @@ package permissions
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/ONSdigital/log.go/v2/log"
+)
+
+// package level constants
+const (
+	bundlerEndpoint = "%s/v1/permissions-bundle"
 )
 
 // Compiler check that the APIClient complies with the Store interface
@@ -21,46 +31,62 @@ type HTTPClient interface {
 type APIClient struct {
 	host    string
 	httpCli HTTPClient
+	backoffSchedule []time.Duration
 }
 
 // NewAPIClient constructs a new APIClient instance.
-func NewAPIClient(host string, httpClient HTTPClient) *APIClient {
+func NewAPIClient(host string, httpClient HTTPClient, backoffSchedule []time.Duration) *APIClient {
 	return &APIClient{
 		host:    host,
 		httpCli: httpClient,
+		backoffSchedule: backoffSchedule,
 	}
 }
 
 // GetPermissionsBundle gets the permissions bundle data from the permissions API.
 func (c *APIClient) GetPermissionsBundle(ctx context.Context) (Bundle, error) {
-
-	uri := fmt.Sprintf("%s/v1/permissions-bundle", c.host)
-
-	req, err := http.NewRequest(http.MethodGet, uri, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.httpCli.Do(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer func() {
-		if resp.Body != nil {
-			resp.Body.Close()
+	// function vars
+	var (
+		permissions Bundle
+		uri = fmt.Sprintf(bundlerEndpoint, c.host)
+		bundlerError error
+		resp *http.Response
+		req *http.Request
+		maxRetryLimit = len(c.backoffSchedule)-1
+	)
+	for retryCount, backOff := range c.backoffSchedule {
+		req, bundlerError = http.NewRequest(http.MethodGet, uri, nil)
+		if bundlerError != nil {
+			break
 		}
-	}()
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("unexpected status returned from the permissions api permissions-bundle endpoint: %s", resp.Status)
-	}
 
-	permissions, err := getPermissionsBundleFromResponse(resp.Body)
-	if err != nil {
-		return nil, err
-	}
+		resp, bundlerError = c.httpCli.Do(ctx, req)
+		if bundlerError != nil {
+			break
+		}
 
-	return permissions, nil
+		defer func() {
+			if resp.Body != nil {
+				resp.Body.Close()
+			}
+		}()
+		
+		//check returned status and take appropriate action
+		if resp.StatusCode != http.StatusOK {
+			// if we've reached the last retry, set retryAllowed to false, error and break from loop
+			if retryCount == maxRetryLimit {
+				bundlerError = errors.New("bundler data not successfully retrieved from service - max retries reached ["+strconv.Itoa(maxRetryLimit)+"] - final response: "+strconv.Itoa(resp.StatusCode))
+				break
+			} else {
+				log.Info(ctx, "unexpected status returned from the permissions api permissions-bundle endpoint: %s - retrying...", log.Data{"response": resp.Status})
+			}
+		} else {
+			permissions, bundlerError = getPermissionsBundleFromResponse(resp.Body)
+			break
+		}
+		time.Sleep(backOff)
+	}
+	return permissions, bundlerError
 }
 
 func getPermissionsBundleFromResponse(reader io.Reader) (Bundle, error) {


### PR DESCRIPTION
Ensure that when building the permissions cache on startup, an exponential backoff algorithm is employed to retry the `dp-permissions-api - /v1/permissions-bundle` endpoint if error encountered.

Otherwise, library waits the allocated `5` minute interval, leaving healthcheck in critical state for this `5` minute duration. 