### PR TITLE
'=' condition changed to 'StringEquals' and added 'StartsWith' condition

### DIFF
--- a/v2/permissions/api_client_test.go
+++ b/v2/permissions/api_client_test.go
@@ -57,7 +57,7 @@ func TestAPIClient_GetPermissionsBundle(t *testing.T) {
 				So(policy.ID, ShouldEqual, "policy/123")
 				So(policy.Conditions[0].Attributes, ShouldHaveLength, 1)
 				So(policy.Conditions[0].Attributes[0], ShouldEqual, "collection_id")
-				So(policy.Conditions[0].Operator, ShouldEqual, "equals")
+				So(policy.Conditions[0].Operator, ShouldEqual, "StringEquals")
 				So(policy.Conditions[0].Values, ShouldHaveLength, 1)
 				So(policy.Conditions[0].Values[0], ShouldEqual, "col123")
 			})
@@ -111,7 +111,7 @@ func TestAPIClient_GetPermissionsBundle_SucceedsOnSecondAttempt(t *testing.T) {
 				So(policy.ID, ShouldEqual, "policy/123")
 				So(policy.Conditions[0].Attributes, ShouldHaveLength, 1)
 				So(policy.Conditions[0].Attributes[0], ShouldEqual, "collection_id")
-				So(policy.Conditions[0].Operator, ShouldEqual, "equals")
+				So(policy.Conditions[0].Operator, ShouldEqual, "StringEquals")
 				So(policy.Conditions[0].Values, ShouldHaveLength, 1)
 				So(policy.Conditions[0].Values[0], ShouldEqual, "col123")
 			})
@@ -249,7 +249,7 @@ func getExampleBundle() permissions.Bundle {
 					Conditions: []permissions.Condition{
 						{
 							Attributes: []string{"collection_id"},
-							Operator:   "equals",
+							Operator:   "StringEquals",
 							Values:     []string{"col123"}},
 					},
 				},

--- a/v2/permissions/checker.go
+++ b/v2/permissions/checker.go
@@ -10,6 +10,7 @@ package permissions
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -159,7 +160,10 @@ func conditionIsMet(condition Condition, attributes map[string]string) bool {
 		}
 
 		for _, conditionValue := range condition.Values {
-			if condition.Operator == "=" && value == conditionValue {
+			if condition.Operator == OperatorStringEquals && value == conditionValue {
+				return true
+			}
+			if condition.Operator == OperatorStartsWith && strings.HasPrefix(value, conditionValue) {
 				return true
 			}
 		}

--- a/v2/permissions/model.go
+++ b/v2/permissions/model.go
@@ -15,9 +15,12 @@ type Policy struct {
 // Condition is used within a policy to match additional attributes.
 type Condition struct {
 	Attributes []string `json:"attributes"`
-	Operator   string   `json:"operator"`
+	Operator   Operator `json:"operator"`
 	Values     []string `json:"values"`
 }
+
+// Operator is used to define a set of supported Condition operators
+type Operator string
 
 // EntityData groups the different entity types into a single parameter
 type EntityData struct {
@@ -25,3 +28,8 @@ type EntityData struct {
 	ServiceID string
 	Groups    []string
 }
+
+const (
+	OperatorStringEquals Operator = "StringEquals"
+	OperatorStartsWith   Operator = "StartsWith"
+)


### PR DESCRIPTION
### What

Condition operators changed from symbol to keyword based. '=' condition operator changed to 'StringEquals' and support for new 'StartsWith' operator added.  Keyword operators are case-sensitive.

### How to review

Review code changes inc. operators implemented as a string enum.  Check unit tests.

### Who can review

Anyone
