### PR TITLE
Check Kid field in JWT header.

### DIFF
--- a/v2/authorisation/middleware.go
+++ b/v2/authorisation/middleware.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	jwtIdentifier = "JWT"
 	chunkSize = 3
 )
 
@@ -121,7 +120,7 @@ func (m PermissionCheckMiddleware) Require(permission string, handlerFunc http.H
 			entityData = &permissions.EntityData{}
 			err error
 		)
-		if headerData.Typ == jwtIdentifier {
+		if headerData.Kid != "" {
 			entityData, err = m.jwtParser.Parse(authToken)
 			if err != nil {
 				logData["message"] = err.Error()


### PR DESCRIPTION
The library cannot rely on the `Typ` field being set in the `JWT` header being returned from `AWS Cognito`. However, the `JWKS  Key ID` field will always be set.

This field will be used by the library to check if the authentication token is a `JWT`.