### PR TITLE
Feature/add enable flag

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What
+
+Describe what you have changed and why.
+
+### How to review
+
+Describe the steps required to test the changes.
+
+### Who can review
+
+Describe who worked on the changes, so that other people can review.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,91 +1,81 @@
-# This file was inspired by the golangci-lint one:
-# https://github.com/golangci/golangci-lint/blob/master/.golangci.yml
+version: "2"
 run:
-  # default concurrency is a available CPU number
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
-linters-settings:
-  govet:
-    shadow: true
-  golint:
-    min-confidence: 0
-  gocyclo:
-    min-complexity: 20
-  gocognit:
-    min-complexity: 40
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: UK
-  lll:
-    line-length: 140
-  gofmt:
-    simplify: false
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - wrapperFunc
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - hugeParam
-  funlen:
-  # lines: 100
-  # statements: 100
-
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - dogsled
     - errcheck
     - gochecknoinits
+    - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - revive
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - nakedret
+    - prealloc
+    - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
     - whitespace
-    - gocognit
-    - prealloc
-
+  settings:
+    dupl:
+      threshold: 100
+    gocognit:
+      min-complexity: 40
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - hugeParam
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 20
+    lll:
+      line-length: 140
+    misspell:
+      locale: UK
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - gocyclo
+          - gosec
+          - revive
+        path: _test\.go
+      - linters:
+          - revive
+        path: _test.go
+        text: dot-imports
+        source: github.com/smartystreets/goconvey/convey
 issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-        - gosec
-        - revive
-    # Allow dot import in test files for goconvey
-    - path: _test.go
-      text: "dot-imports"
-      linters:
-        - revive
-      source: "github.com/smartystreets/goconvey/convey"
   new: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+  exclusions:
+    generated: lax

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,4 @@ build:
 
 .PHONY: lint
 lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
 	golangci-lint run ./...

--- a/authorisation/middleware.go
+++ b/authorisation/middleware.go
@@ -38,7 +38,10 @@ type GetAttributesFromRequest func(req *http.Request) (attributes map[string]str
 
 // NewFeatureFlaggedMiddleware returns a different Middleware implementation depending on the configured feature flag value
 // Use this constructor when first adding authorisation as middleware so that it can be toggled off if required.
-func NewFeatureFlaggedMiddleware(_ context.Context, _ *Config, _ map[string]string) (Middleware, error) {
+func NewFeatureFlaggedMiddleware(ctx context.Context, config *Config, jwtRSAPublicKeys map[string]string) (Middleware, error) {
+	if config.Enabled {
+		return NewMiddlewareFromConfig(ctx, config, jwtRSAPublicKeys)
+	}
 	return NewNoopMiddleware(), nil
 }
 

--- a/authorisationtest/fake_permissions_api.go
+++ b/authorisationtest/fake_permissions_api.go
@@ -33,7 +33,7 @@ func NewFakePermissionsAPI() *FakePermissionsAPI {
 // URL returns the URL of the HTTP server. This can be used in the setup of the component test to override
 // the default URL for the permission API.
 func (f *FakePermissionsAPI) URL() string {
-	return f.HTTPFake.Server.URL
+	return f.Server.URL
 }
 
 // UpdatePermissionsBundleResponse overrides the default response to return custom permission bundle data.

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -5,8 +5,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: golang
-    tag: latest
+    repository: onsdigital/dp-concourse-tools-lint-go
+    tag: 1.24.4-bullseye-golangci-lint-2
 
 inputs:
   - name: dp-authorisation


### PR DESCRIPTION
### What

- Re-added the enable flag back to the feature flagged middleware.
- Add PR template
- Upgrade linter to v2

### How to review

Check looks ok - I am directly retracting some of this PR here: https://github.com/ONSdigital/dp-authorisation/pull/58 

However, this results in a feature flagged middleware that does no feature flagging. This reinstates that functionality. 

### Who can review

Not me. 