### PR TITLE
Feature/protective montioring logging

### DIFF
--- a/authorisation/middleware.go
+++ b/authorisation/middleware.go
@@ -112,7 +112,7 @@ func (m PermissionCheckMiddleware) RequireWithAttributes(permission string, hand
 
 		authToken := req.Header.Get("Authorization")
 		if authToken == "" {
-			log.Info(ctx, "authorisation failed: no authorisation header in request", logData)
+			log.Info(ctx, "authorisation failed: no authorisation header in request", log.Classification(log.ProtectiveMonitoring), logData)
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
@@ -123,32 +123,36 @@ func (m PermissionCheckMiddleware) RequireWithAttributes(permission string, hand
 		var (
 			entityData              = &permsdk.EntityData{}
 			zebedeeIdentityResponse = &request.IdentityResponse{}
+			identityType            = log.USER
 			err                     error
 		)
 		if strings.Contains(authToken, ".") {
 			entityData, err = m.jwtParser.Parse(authToken)
 			if err != nil {
 				if errors.Is(err, jwt.ErrPublickeysEmpty) {
-					log.Error(ctx, "no public keys", err)
+					log.Error(ctx, "no public keys", err, logData)
 					w.WriteHeader(http.StatusInternalServerError)
 				} else {
 					logData["message"] = err.Error()
-					log.Error(ctx, "authorisation failed: unable to parse jwt", err, logData)
+					log.Error(ctx, "authorisation failed: unable to parse jwt", err, log.Classification(log.ProtectiveMonitoring), log.Auth(identityType, ""), logData)
 					w.WriteHeader(http.StatusUnauthorized)
 				}
 				return
 			}
 		} else {
+			identityType = log.SERVICE
 			zebedeeIdentityResponse, err = m.zebedeeClient.CheckTokenIdentity(ctx, authToken)
 			if err != nil {
 				logData["message"] = err.Error()
-				log.Error(ctx, "authorisation failed: service token issue", err, logData)
+				log.Error(ctx, "authorisation failed: service token issue", err, log.Classification(log.ProtectiveMonitoring), log.Auth(identityType, ""), logData)
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}
 			// extract user name and proceed
 			entityData.UserID = zebedeeIdentityResponse.Identifier
 		}
+
+		logAuthOption := log.Auth(identityType, entityData.UserID)
 
 		var attributes map[string]string
 		if getAttributes != nil {
@@ -168,10 +172,13 @@ func (m PermissionCheckMiddleware) RequireWithAttributes(permission string, hand
 		}
 
 		if !hasPermission {
-			log.Info(ctx, "authorisation failed: request has no permission", logData)
+			logData["message"] = "user/service does not have required permission"
+			log.Info(ctx, "authorisation failed: request has no permission", log.Classification(log.ProtectiveMonitoring), logAuthOption, logData)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
+
+		log.Info(ctx, "authorisation successful", log.Classification(log.ProtectiveMonitoring), logAuthOption, logData)
 
 		handlerFunc(w, req)
 	}

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.11-bookworm
+    tag: 1.24.13-bookworm
 
 inputs:
   - name: dp-authorisation

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.24.11-bookworm-golangci-lint-2
+    tag: 1.24.13-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-authorisation

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.11-bookworm
+    tag: 1.24.13-bookworm
 
 inputs:
   - name: dp-authorisation

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-net/v3 v3.8.0
 	github.com/ONSdigital/dp-permissions-api v1.10.0
-	github.com/ONSdigital/log.go/v2 v2.5.0
+	github.com/ONSdigital/log.go/v2 v2.5.2
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/maxcnunes/httpfake v1.2.4
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/ONSdigital/dp-net/v3 v3.8.0 h1:4VYHBryZyN/4Aa3SywJIwuNF3Ey6JRoZbWO1Wb
 github.com/ONSdigital/dp-net/v3 v3.8.0/go.mod h1:ur4LLCvd2xW2jpa785pElE6HB2bPvszZxdAjqv0XFGg=
 github.com/ONSdigital/dp-permissions-api v1.10.0 h1:iAdeeDSX84AJrhljIaVvPyenZP/Nu30o8duY89rvXlI=
 github.com/ONSdigital/dp-permissions-api v1.10.0/go.mod h1:HfQYvW7eLeJDIBRbwtES8Gr49yJvc4Zs3YgsQZulABk=
-github.com/ONSdigital/log.go/v2 v2.5.0 h1:gFHAn6tLOzkhC9hiAFgFxzNBh5Uz06KyULQ9aQyM9tE=
-github.com/ONSdigital/log.go/v2 v2.5.0/go.mod h1:0ilpZzc5lVoBlXC/s5m8EaQETbe0yT8Z+p4QhKy0fpY=
+github.com/ONSdigital/log.go/v2 v2.5.2 h1:V6NYtbi+thHYTwckxOXPklZUgQCNBo1/fyPPIutu4V4=
+github.com/ONSdigital/log.go/v2 v2.5.2/go.mod h1:KZNEweCUHD8dKwhlvoRvgd2Y2aUIuU3H9/MmbFyVzW8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=


### PR DESCRIPTION
### What

Ticket:
https://officefornationalstatistics.atlassian.net/browse/DIS-4559

- Add classification tag to log messages for 403 and 401 responses
- Add log for successful requests
- No additional logging for 500 status code errors as this is not included in acceptance criteria. (500 does not necessarily mean the request did not have sufficient permissions)
- Include Auth data where possible (early failures do not have a UserID but IdentityType is known)

Note: some errors are logged as `log.Info` within the auth middleware. I decided to keep logging levels the same as they were instead of updating them to `log.error` and creating an internal list of `error` variables. I assume it must've been intentional.

### How to review

- Locally replace `dp-authorisation` within a service (such as dp-dataset-api) with this branch
- Make requests that return 401 and 403 errors. Check the required information is included in logs.
- Logs can be seen with `docker logs int-dataset-catalogue-dp-dataset-api-1 -f`
- Ensure successful requests are also including the required information in logs

Example logs in a successful request:
```
{
  "auth": {
    "identity": "{{UUID}}",
    "identity_type": "user"
  },
  "classification": "PROTECTIVE_MONITORING",
  "created_at": "{{timestamp}}",
  "data": {
    "permission": "datasets:create",
    "url": "/datasets"
  },
  "event": "authorisation successful",
  "namespace": "dp-dataset-api",
  "severity": 3,
  "trace_id": "gjOFhMpBFCTVACJK"
}
```
This displays all required information:
- Time: `created_at`
- Who: `auth`
- Action: covered by `data.permission` and `data.url`
- Outcome: `event`


### Who can review

Describe who worked on the changes, so that other people can review.
