### PR TITLE
Use latest patch version of the Permissions API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.270.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-net/v3 v3.8.0
-	github.com/ONSdigital/dp-permissions-api v1.10.0
+	github.com/ONSdigital/dp-permissions-api v1.10.1
 	github.com/ONSdigital/log.go/v2 v2.5.2
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/maxcnunes/httpfake v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/ONSdigital/dp-mocking v0.11.0 h1:laln6e2JD4vtsYbg0cTw9ur1Xf390AUYdd85
 github.com/ONSdigital/dp-mocking v0.11.0/go.mod h1:oHkuukWnURnK7epY5TD5oYVkOwldR2La1D5LQBTxY0A=
 github.com/ONSdigital/dp-net/v3 v3.8.0 h1:4VYHBryZyN/4Aa3SywJIwuNF3Ey6JRoZbWO1Wb+tPUc=
 github.com/ONSdigital/dp-net/v3 v3.8.0/go.mod h1:ur4LLCvd2xW2jpa785pElE6HB2bPvszZxdAjqv0XFGg=
-github.com/ONSdigital/dp-permissions-api v1.10.0 h1:iAdeeDSX84AJrhljIaVvPyenZP/Nu30o8duY89rvXlI=
-github.com/ONSdigital/dp-permissions-api v1.10.0/go.mod h1:HfQYvW7eLeJDIBRbwtES8Gr49yJvc4Zs3YgsQZulABk=
+github.com/ONSdigital/dp-permissions-api v1.10.1 h1:dOyPtS94CpBgS0Y1oZJy84UcKZOHkmDK+Zdg5OClEXs=
+github.com/ONSdigital/dp-permissions-api v1.10.1/go.mod h1:436ej+daY+8+hNCReDvCIsI0iNRWKU/UZsxC09CRMNA=
 github.com/ONSdigital/log.go/v2 v2.5.2 h1:V6NYtbi+thHYTwckxOXPklZUgQCNBo1/fyPPIutu4V4=
 github.com/ONSdigital/log.go/v2 v2.5.2/go.mod h1:KZNEweCUHD8dKwhlvoRvgd2Y2aUIuU3H9/MmbFyVzW8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
### What

I've increased the version of the Permissions API to the latest patch, 1.10.1, because it's being used by the Redirect API, which I'm currently testing in sandbox. 

The Redirect API was giving an error, when started up in sandbox, with the message "failed to update permissions cache" . It looks like this might be part of a fix for that.

### How to review

Sense check. Tests pass.

### Who can review

Anyone.