### PR TITLE
feat(DIS-4827): update auth middleware to validate auth entity data and populate context

### DIFF
--- a/authorisation/auth_entity_context.go
+++ b/authorisation/auth_entity_context.go
@@ -1,0 +1,18 @@
+package authorisation
+
+import "context"
+
+// authEntityDataKey is the key used to store the AuthEntityData in the context
+// it is a private type to prevent collisions with other keys in the context
+type authEntityDataKey struct{}
+
+// ContextWithAuthEntityData adds the AuthEntityData to the context
+func ContextWithAuthEntityData(ctx context.Context, data *AuthEntityData) context.Context {
+	return context.WithValue(ctx, authEntityDataKey{}, data)
+}
+
+// AuthEntityDataFromContext retrieves the AuthEntityData from the context
+func AuthEntityDataFromContext(ctx context.Context) (*AuthEntityData, bool) {
+	data, ok := ctx.Value(authEntityDataKey{}).(*AuthEntityData)
+	return data, ok
+}

--- a/authorisation/auth_entity_context_test.go
+++ b/authorisation/auth_entity_context_test.go
@@ -1,0 +1,42 @@
+package authorisation
+
+import (
+	"context"
+	"testing"
+
+	permsdk "github.com/ONSdigital/dp-permissions-api/sdk"
+)
+
+func TestContextWithAuthEntityDataAndFromContext(t *testing.T) {
+	ctx := context.Background()
+	expected := &AuthEntityData{
+		EntityData: &permsdk.EntityData{
+			UserID: "test-user",
+			Groups: []string{"group-a"},
+		},
+		IsServiceAuth: true,
+	}
+
+	ctxWithData := ContextWithAuthEntityData(ctx, expected)
+	got, ok := AuthEntityDataFromContext(ctxWithData)
+	if !ok {
+		t.Fatal("expected auth entity data in context, got none")
+	}
+
+	if got != expected {
+		t.Fatalf("expected same auth entity data pointer, got different pointer")
+	}
+}
+
+func TestAuthEntityDataFromContextWhenMissing(t *testing.T) {
+	ctx := context.Background()
+
+	got, ok := AuthEntityDataFromContext(ctx)
+	if ok {
+		t.Fatal("expected no auth entity data in context")
+	}
+
+	if got != nil {
+		t.Fatalf("expected nil auth entity data, got %#v", got)
+	}
+}

--- a/authorisation/auth_entity_context_test.go
+++ b/authorisation/auth_entity_context_test.go
@@ -1,42 +1,48 @@
-package authorisation
+package authorisation_test
 
 import (
 	"context"
 	"testing"
 
+	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 	permsdk "github.com/ONSdigital/dp-permissions-api/sdk"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestContextWithAuthEntityDataAndFromContext(t *testing.T) {
-	ctx := context.Background()
-	expected := &AuthEntityData{
-		EntityData: &permsdk.EntityData{
-			UserID: "test-user",
-			Groups: []string{"group-a"},
-		},
-		IsServiceAuth: true,
-	}
+	Convey("Given auth entity data and a base context", t, func() {
+		ctx := context.Background()
+		expected := &authorisation.AuthEntityData{
+			EntityData: &permsdk.EntityData{
+				UserID: "test-user",
+				Groups: []string{"group-a"},
+			},
+			IsServiceAuth: true,
+		}
 
-	ctxWithData := ContextWithAuthEntityData(ctx, expected)
-	got, ok := AuthEntityDataFromContext(ctxWithData)
-	if !ok {
-		t.Fatal("expected auth entity data in context, got none")
-	}
+		Convey("When the auth entity data is added to context", func() {
+			ctxWithData := authorisation.ContextWithAuthEntityData(ctx, expected)
+			got, ok := authorisation.AuthEntityDataFromContext(ctxWithData)
 
-	if got != expected {
-		t.Fatalf("expected same auth entity data pointer, got different pointer")
-	}
+			Convey("Then the same auth entity data is returned", func() {
+				So(ok, ShouldBeTrue)
+				So(got, ShouldEqual, expected)
+			})
+		})
+	})
 }
 
 func TestAuthEntityDataFromContextWhenMissing(t *testing.T) {
-	ctx := context.Background()
+	Convey("Given a context without auth entity data", t, func() {
+		ctx := context.Background()
 
-	got, ok := AuthEntityDataFromContext(ctx)
-	if ok {
-		t.Fatal("expected no auth entity data in context")
-	}
+		Convey("When auth entity data is retrieved from context", func() {
+			got, ok := authorisation.AuthEntityDataFromContext(ctx)
 
-	if got != nil {
-		t.Fatalf("expected nil auth entity data, got %#v", got)
-	}
+			Convey("Then no auth entity data is found", func() {
+				So(ok, ShouldBeFalse)
+				So(got, ShouldBeNil)
+			})
+		})
+	})
 }

--- a/authorisation/auth_entity_model.go
+++ b/authorisation/auth_entity_model.go
@@ -1,0 +1,22 @@
+package authorisation
+
+import permsdk "github.com/ONSdigital/dp-permissions-api/sdk"
+
+// AuthEntityData holds the entity data for an authenticated request along with
+// whether the request was made by a service account or user
+type AuthEntityData struct {
+	EntityData    *permsdk.EntityData
+	IsServiceAuth bool
+}
+
+// CreateAuthEntityData creates an AuthEntityData from the provided EntityData and
+// a bool indicating whether the token belongs to a service account
+func CreateAuthEntityData(entityData *permsdk.EntityData, isService bool) *AuthEntityData {
+	return &AuthEntityData{
+		EntityData: &permsdk.EntityData{
+			UserID: entityData.UserID,
+			Groups: entityData.Groups,
+		},
+		IsServiceAuth: isService,
+	}
+}

--- a/authorisation/auth_entity_model_test.go
+++ b/authorisation/auth_entity_model_test.go
@@ -1,0 +1,59 @@
+package authorisation
+
+import (
+	"testing"
+
+	permsdk "github.com/ONSdigital/dp-permissions-api/sdk"
+)
+
+func TestCreateAuthEntityData(t *testing.T) {
+	entityData := &permsdk.EntityData{
+		UserID: "test-user",
+		Groups: []string{"group-a", "group-b"},
+	}
+
+	tests := []struct {
+		name      string
+		isService bool
+	}{
+		{
+			name:      "service auth",
+			isService: true,
+		},
+		{
+			name:      "user auth",
+			isService: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CreateAuthEntityData(entityData, tc.isService)
+			if got == nil {
+				t.Fatal("expected auth entity data, got nil")
+			}
+
+			if got.EntityData == nil {
+				t.Fatal("expected entity data, got nil")
+			}
+
+			if got.EntityData.UserID != entityData.UserID {
+				t.Fatalf("expected user id %q, got %q", entityData.UserID, got.EntityData.UserID)
+			}
+
+			if len(got.EntityData.Groups) != len(entityData.Groups) {
+				t.Fatalf("expected %d groups, got %d", len(entityData.Groups), len(got.EntityData.Groups))
+			}
+
+			for i := range entityData.Groups {
+				if got.EntityData.Groups[i] != entityData.Groups[i] {
+					t.Fatalf("expected group %q at index %d, got %q", entityData.Groups[i], i, got.EntityData.Groups[i])
+				}
+			}
+
+			if got.IsServiceAuth != tc.isService {
+				t.Fatalf("expected IsServiceAuth %t, got %t", tc.isService, got.IsServiceAuth)
+			}
+		})
+	}
+}

--- a/authorisation/auth_entity_model_test.go
+++ b/authorisation/auth_entity_model_test.go
@@ -1,59 +1,39 @@
-package authorisation
+package authorisation_test
 
 import (
 	"testing"
 
+	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 	permsdk "github.com/ONSdigital/dp-permissions-api/sdk"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestCreateAuthEntityData(t *testing.T) {
-	entityData := &permsdk.EntityData{
-		UserID: "test-user",
-		Groups: []string{"group-a", "group-b"},
-	}
+	Convey("Given entity data", t, func() {
+		entityData := &permsdk.EntityData{
+			UserID: "test-user",
+			Groups: []string{"group-a", "group-b"},
+		}
 
-	tests := []struct {
-		name      string
-		isService bool
-	}{
-		{
-			name:      "service auth",
-			isService: true,
-		},
-		{
-			name:      "user auth",
-			isService: false,
-		},
-	}
+		Convey("When auth entity data is created for service auth", func() {
+			got := authorisation.CreateAuthEntityData(entityData, true)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := CreateAuthEntityData(entityData, tc.isService)
-			if got == nil {
-				t.Fatal("expected auth entity data, got nil")
-			}
-
-			if got.EntityData == nil {
-				t.Fatal("expected entity data, got nil")
-			}
-
-			if got.EntityData.UserID != entityData.UserID {
-				t.Fatalf("expected user id %q, got %q", entityData.UserID, got.EntityData.UserID)
-			}
-
-			if len(got.EntityData.Groups) != len(entityData.Groups) {
-				t.Fatalf("expected %d groups, got %d", len(entityData.Groups), len(got.EntityData.Groups))
-			}
-
-			for i := range entityData.Groups {
-				if got.EntityData.Groups[i] != entityData.Groups[i] {
-					t.Fatalf("expected group %q at index %d, got %q", entityData.Groups[i], i, got.EntityData.Groups[i])
-				}
-			}
-
-			if got.IsServiceAuth != tc.isService {
-				t.Fatalf("expected IsServiceAuth %t, got %t", tc.isService, got.IsServiceAuth)
-			}
+			Convey("Then auth entity data contains the expected values", func() {
+				So(got, ShouldNotBeNil)
+				So(got.EntityData, ShouldNotBeNil)
+				So(got.EntityData.UserID, ShouldEqual, entityData.UserID)
+				So(got.EntityData.Groups, ShouldResemble, entityData.Groups)
+				So(got.IsServiceAuth, ShouldBeTrue)
+			})
 		})
-	}
+
+		Convey("When auth entity data is created for user auth", func() {
+			got := authorisation.CreateAuthEntityData(entityData, false)
+
+			Convey("Then the service auth flag is false", func() {
+				So(got, ShouldNotBeNil)
+				So(got.IsServiceAuth, ShouldBeFalse)
+			})
+		})
+	})
 }

--- a/authorisation/middleware.go
+++ b/authorisation/middleware.go
@@ -180,7 +180,10 @@ func (m PermissionCheckMiddleware) RequireWithAttributes(permission string, hand
 
 		log.Info(ctx, "authorisation successful", log.Classification(log.ProtectiveMonitoring), logAuthOption, logData)
 
-		handlerFunc(w, req)
+		authEntityData := CreateAuthEntityData(entityData, identityType == log.SERVICE)
+		ctx = ContextWithAuthEntityData(ctx, authEntityData)
+
+		handlerFunc(w, req.WithContext(ctx))
 	}
 }
 

--- a/authorisation/middleware_test.go
+++ b/authorisation/middleware_test.go
@@ -123,6 +123,59 @@ func TestMiddleware_RequireWithAttributes(t *testing.T) {
 	})
 }
 
+func TestMiddleware_RequireWithAttributes_AddsAuthEntityDataToHandlerRequestContext(t *testing.T) {
+	Convey("Given a request with a valid JWT token that has the required permissions", t, func() {
+		response := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, testURL, http.NoBody)
+		request.Header.Set("Authorization", authorisationtest.AdminJWTToken)
+
+		_, originalHasAuthEntityData := authorisation.AuthEntityDataFromContext(request.Context())
+		mockJWTParser := newMockJWTParser()
+		permissionsChecker := &mock.PermissionsCheckerMock{
+			HasPermissionFunc: func(ctx context.Context, entityData permsdk.EntityData, permission string, attributes map[string]string) (bool, error) {
+				return true, nil
+			},
+		}
+
+		var (
+			handlerAuthEntityData    *authorisation.AuthEntityData
+			handlerHasAuthEntityData bool
+			handlerCalls             int
+		)
+
+		handler := func(_ http.ResponseWriter, req *http.Request) {
+			handlerCalls++
+			handlerAuthEntityData, handlerHasAuthEntityData = authorisation.AuthEntityDataFromContext(req.Context())
+		}
+
+		middleware := authorisation.NewMiddlewareFromDependencies(mockJWTParser, permissionsChecker, zebedeeIdentity, identityClient)
+		middlewareFunc := middleware.RequireWithAttributes(permission, handler, nil)
+
+		Convey("When the middleware function is called", func() {
+			middlewareFunc(response, request)
+
+			Convey("Then the original request context is unchanged", func() {
+				_, ok := authorisation.AuthEntityDataFromContext(request.Context())
+				So(originalHasAuthEntityData, ShouldBeFalse)
+				So(ok, ShouldBeFalse)
+			})
+
+			Convey("Then the wrapped handler receives a request with auth entity data in context", func() {
+				So(handlerCalls, ShouldEqual, 1)
+				So(handlerHasAuthEntityData, ShouldBeTrue)
+				So(handlerAuthEntityData, ShouldNotBeNil)
+				So(handlerAuthEntityData.EntityData, ShouldNotBeNil)
+				So(handlerAuthEntityData.EntityData.UserID, ShouldEqual, dummyEntityData.UserID)
+				So(handlerAuthEntityData.IsServiceAuth, ShouldBeFalse)
+			})
+
+			Convey("Then the response code should be 200", func() {
+				So(response.Code, ShouldEqual, http.StatusOK)
+			})
+		})
+	})
+}
+
 func TestMiddleware_Require(t *testing.T) {
 	Convey("Given a request with a valid JWT token that has the required permissions", t, func() {
 		response := httptest.NewRecorder()

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -1,12 +1,11 @@
 ---
-
 platform: linux
 
 image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: latest
 
 inputs:
   - name: dp-authorisation

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.13-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-authorisation

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.2-bookworm-golangci-lint-2
+    tag: latest
 
 inputs:
   - name: dp-authorisation

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -1,12 +1,11 @@
 ---
-
 platform: linux
 
 image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.24.13-bookworm-golangci-lint-2
+    tag: 1.26.2-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-authorisation

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -1,12 +1,11 @@
 ---
-
 platform: linux
 
 image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.2-bookworm
+    tag: latest
 
 inputs:
   - name: dp-authorisation

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.13-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-authorisation

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-authorisation/v2
 
-go 1.26.0
+go 1.24.0
 
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.270.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-authorisation/v2
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.270.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-authorisation/v2
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.270.0


### PR DESCRIPTION
### What

In the middleware we now populate the entity data in a composite data structure within the request context.

### How to review

Added replace directive to dp-permissions-api for authorisation middleware library.
Test with dp-authentication-stub to ensure multiple incoming requests receive 200's

### Who can review

!me
