### PR TITLE
fix(DIS-4879): dp-permissions-api fails to update permissions cache on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,46 @@ For the typical case of adding authorisation as middleware, the JWT parsing and 
 
 Using the `NewFeatureFlaggedMiddleware` constructor will use the `Enabled` config value to automatically apply a feature flag to authorisation. If the flag is disabled, a no-op instance of middleware will be used. This minimises the amount of code required to apply a feature flag to authorisation. Endpoints can still be wrapped with the authorisation middleware, but it will just act as a pass-through if authorisation is disabled. Should you want to create a middleware instance without a feature flag, use the `NewMiddlewareFromConfig` constructor function instead.
 
+#### Creating middleware with an injected permissions store
+
+Most services should use `NewFeatureFlaggedMiddleware`, which creates a permissions checker backed by the permissions API URL from config.
+
+Some services may already have direct access to permissions bundle data and should not call the permissions API over HTTP. For example, `dp-permissions-api` can build the permissions bundle locally, so calling its own `/v1/permissions-bundle` endpoint during startup can create a loopback dependency before the HTTP server is ready.
+
+For this case, use `NewFeatureFlaggedMiddlewareWithPermissionsStore` and provide an implementation of `permissions.Store`:
+
+```go
+import (
+    "context"
+
+    "github.com/ONSdigital/dp-authorisation/v2/authorisation"
+    "github.com/ONSdigital/dp-authorisation/v2/permissions"
+    permsdk "github.com/ONSdigital/dp-permissions-api/sdk"
+)
+
+type localPermissionsStore struct{}
+
+func (s localPermissionsStore) GetPermissionsBundle(ctx context.Context, headers permsdk.Headers) (permsdk.Bundle, error) {
+    // Return permissions bundle data from a local source.
+    return permsdk.Bundle{}, nil
+}
+
+func createMiddleware(ctx context.Context, authorisationConfig *authorisation.Config) (authorisation.Middleware, error) {
+    store := localPermissionsStore{}
+
+    return authorisation.NewFeatureFlaggedMiddlewareWithPermissionsStore(
+        ctx,
+        authorisationConfig,
+        authorisationConfig.JWTVerificationPublicKeys,
+        store,
+    )
+}
+```
+
+The supplied store is wrapped in the same in-memory permissions cache used by the default middleware path. The cache is still updated on `PermissionsCacheUpdateInterval` and expires data according to `PermissionsMaxCacheTime`.
+
+If authorisation is disabled in config, this constructor returns a no-op middleware and the store is not used. If authorisation is enabled, the store must not be nil.
+
 #### Wrap endpoints using the `authorisationMiddleware.Require` function
 
 ```go
@@ -78,6 +118,8 @@ The above example shows the `POST /v1/users` endpoint being wrapped with authori
         log.Error(ctx, "error adding check for permissions cache", err)
     }
 ```
+
+The permissions cache health check applies to both middleware construction paths. Whether the cache is backed by the permissions API client or an injected `permissions.Store`, services should register `authorisationMiddleware.HealthCheck`.
 
 #### Add a health check for the underlying jwt keys request against identity service
 

--- a/authorisation/auth_entity_context_test.go
+++ b/authorisation/auth_entity_context_test.go
@@ -9,13 +9,18 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const (
+	testUserID = "test-user"
+	testGroupA = "group-a"
+)
+
 func TestContextWithAuthEntityDataAndFromContext(t *testing.T) {
 	Convey("Given auth entity data and a base context", t, func() {
 		ctx := context.Background()
 		expected := &authorisation.AuthEntityData{
 			EntityData: &permsdk.EntityData{
-				UserID: "test-user",
-				Groups: []string{"group-a"},
+				UserID: testUserID,
+				Groups: []string{testGroupA},
 			},
 			IsServiceAuth: true,
 		}

--- a/authorisation/auth_entity_model_test.go
+++ b/authorisation/auth_entity_model_test.go
@@ -8,11 +8,16 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const (
+	modelTestUserID = "test-user"
+	modelTestGroupA = "group-a"
+)
+
 func TestCreateAuthEntityData(t *testing.T) {
 	Convey("Given entity data", t, func() {
 		entityData := &permsdk.EntityData{
-			UserID: "test-user",
-			Groups: []string{"group-a", "group-b"},
+			UserID: modelTestUserID,
+			Groups: []string{modelTestGroupA, "group-b"},
 		}
 
 		Convey("When auth entity data is created for service auth", func() {

--- a/authorisation/middleware.go
+++ b/authorisation/middleware.go
@@ -45,6 +45,15 @@ func NewFeatureFlaggedMiddleware(ctx context.Context, config *Config, jwtRSAPubl
 	return NewNoopMiddleware(), nil
 }
 
+// NewFeatureFlaggedMiddlewareWithPermissionsStore returns a Middleware implementation using the provided permissions store
+// when authorisation is enabled, or a no-op implementation when it is disabled.
+func NewFeatureFlaggedMiddlewareWithPermissionsStore(ctx context.Context, config *Config, jwtRSAPublicKeys map[string]string, store permissions.Store) (Middleware, error) {
+	if config.Enabled {
+		return NewMiddlewareFromConfigWithPermissionsStore(ctx, config, jwtRSAPublicKeys, store)
+	}
+	return NewNoopMiddleware(), nil
+}
+
 // NewMiddlewareFromDependencies creates a new instance of PermissionCheckMiddleware, using injected dependencies
 func NewMiddlewareFromDependencies(jwtParser JWTParser, permissionsChecker PermissionsChecker, zebedeeClient ZebedeeClient, identityClient *identityclient.IdentityClient) *PermissionCheckMiddleware {
 	return &PermissionCheckMiddleware{
@@ -61,6 +70,30 @@ func NewMiddlewareFromDependencies(jwtParser JWTParser, permissionsChecker Permi
 // This constructor uses default dependencies - the Cognito specific JWT parser, caching permissions checker and JWT RSA public signing keys (optional)
 // If different dependencies are required, use the NewMiddlewareFromDependencies constructor.
 func NewMiddlewareFromConfig(ctx context.Context, config *Config, jwtRSAPublicKeys map[string]string) (*PermissionCheckMiddleware, error) {
+	permissionsChecker := permissions.NewChecker(
+		ctx,
+		config.PermissionsAPIURL,
+		config.PermissionsCacheUpdateInterval,
+		config.PermissionsMaxCacheTime,
+	)
+
+	return newMiddlewareFromConfigWithChecker(ctx, config, jwtRSAPublicKeys, permissionsChecker)
+}
+
+// NewMiddlewareFromConfigWithPermissionsStore creates a new instance of PermissionCheckMiddleware with a cache backed by the provided permissions store.
+func NewMiddlewareFromConfigWithPermissionsStore(ctx context.Context, config *Config, jwtRSAPublicKeys map[string]string, store permissions.Store) (*PermissionCheckMiddleware, error) {
+	if store == nil {
+		return nil, errors.New("permissions store cannot be nil")
+	}
+
+	cachingStore := permissions.NewCachingStore(store)
+	cachingStore.StartCacheUpdater(ctx, config.PermissionsCacheUpdateInterval, config.PermissionsMaxCacheTime)
+	permissionsChecker := permissions.NewCheckerForStore(cachingStore)
+
+	return newMiddlewareFromConfigWithChecker(ctx, config, jwtRSAPublicKeys, permissionsChecker)
+}
+
+func newMiddlewareFromConfigWithChecker(ctx context.Context, config *Config, jwtRSAPublicKeys map[string]string, permissionsChecker PermissionsChecker) (*PermissionCheckMiddleware, error) {
 	// identity client retrieves jwt keys from identity service
 	identityClient, err := identityclient.NewIdentityClient(config.IdentityWebKeySetURL, config.IdentityClientMaxRetries)
 	if err != nil {
@@ -82,13 +115,6 @@ func NewMiddlewareFromConfig(ctx context.Context, config *Config, jwtRSAPublicKe
 		return nil, err
 	}
 	identityClient.CognitoRSAParser = jwtParser
-
-	permissionsChecker := permissions.NewChecker(
-		ctx,
-		config.PermissionsAPIURL,
-		config.PermissionsCacheUpdateInterval,
-		config.PermissionsMaxCacheTime,
-	)
 
 	zebedeeClient := zebedeeclient.NewZebedeeClient(config.ZebedeeURL)
 

--- a/authorisation/middleware_test.go
+++ b/authorisation/middleware_test.go
@@ -22,26 +22,32 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const (
+	middlewareCollectionIDAttribute = "collection_id"
+	testServiceUserID               = "bilbo.baggins@bilbo-baggins.io"
+	testJWTPublicKey                = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmwIDAQAB"
+)
+
 var (
 	dummyEntityData             = &permsdk.EntityData{UserID: "fred"}
-	dummyAttributesData         = &map[string]string{"collection_id": "some-collection_id-uuid"}
+	dummyAttributesData         = &map[string]string{middlewareCollectionIDAttribute: "some-collection_id-uuid"}
 	permission                  = "dataset.read"
-	dummyServiveTokenEntityData = &permsdk.EntityData{UserID: "bilbo.baggins@bilbo-baggins.io"}
+	dummyServiveTokenEntityData = &permsdk.EntityData{UserID: testServiceUserID}
 	zebedeeIdentity             = &mock.ZebedeeClientMock{
 		CheckTokenIdentityFunc: func(ctx context.Context, token string) (*dprequest.IdentityResponse, error) {
 			return &dprequest.IdentityResponse{
-				Identifier: "bilbo.baggins@bilbo-baggins.io",
+				Identifier: testServiceUserID,
 			}, nil
 		},
 	}
 	trimmedToken             = strings.TrimPrefix(authorisationtest.AdminJWTToken, "Bearer ")
 	testURL                  = "https://the-url.com"
 	testJWTPublicKeyAPIMapx1 = map[string]string{
-		"test789=": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmwIDAQAB",
+		"test789=": testJWTPublicKey,
 	}
 	testJWTPublicKeyAPIMapx2 = map[string]string{
-		"test123=": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmwIDAQAB",
-		"test456=": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmwIDAQAB",
+		"test123=": testJWTPublicKey,
+		"test456=": testJWTPublicKey,
 	}
 )
 
@@ -183,7 +189,7 @@ func TestMiddleware_Require(t *testing.T) {
 		request := httptest.NewRequest(http.MethodGet, testURL, http.NoBody)
 		request.Header.Set("Authorization", authorisationtest.AdminJWTToken)
 		request.Header.Set("Collection-Id", "123abc")
-		expectMap := map[string]string{"collection_id": "123abc"}
+		expectMap := map[string]string{middlewareCollectionIDAttribute: "123abc"}
 		mockHandler := &mockHandler{calls: 0}
 		mockJWTParser := newMockJWTParser()
 
@@ -479,7 +485,7 @@ func TestMiddleware_ServiceTokenUser_ZebedeeIdentityVerificationError(t *testing
 func TestGetCollectionIdAttribute(t *testing.T) {
 	Convey("Given a request with a Collection-Id header", t, func() {
 		request := httptest.NewRequest(http.MethodGet, testURL, http.NoBody)
-		request.Header.Set("Collection-Id", (*dummyAttributesData)["collection_id"])
+		request.Header.Set("Collection-Id", (*dummyAttributesData)[middlewareCollectionIDAttribute])
 
 		Convey("When the function is called", func() {
 			attributes, err := authorisation.GetCollectionIDAttribute(request)

--- a/authorisation/middleware_test.go
+++ b/authorisation/middleware_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ONSdigital/dp-authorisation/v2/identityclient"
 	identityClientMock "github.com/ONSdigital/dp-authorisation/v2/identityclient/mock"
 	"github.com/ONSdigital/dp-authorisation/v2/jwt"
+	permissionsMock "github.com/ONSdigital/dp-authorisation/v2/permissions/mock"
 	dprequest "github.com/ONSdigital/dp-net/v3/request"
 	permsdk "github.com/ONSdigital/dp-permissions-api/sdk"
 	. "github.com/smartystreets/goconvey/convey"
@@ -567,6 +568,60 @@ func TestMiddleware_NewFeatureFlaggedMiddleware(t *testing.T) {
 
 		Convey("Then a middleware from config is returned", func() {
 			So(reflect.TypeOf(middleware), ShouldEqual, reflect.TypeOf(&authorisation.PermissionCheckMiddleware{}))
+		})
+	})
+}
+
+func TestMiddleware_NewFeatureFlaggedMiddlewareWithPermissionsStore(t *testing.T) {
+	Convey("When a config is supplied with no enable flag set and no permissions store", t, func() {
+		config := authorisation.NewDefaultConfig()
+		middleware, err := authorisation.NewFeatureFlaggedMiddlewareWithPermissionsStore(context.Background(), config, map[string]string{}, nil)
+		So(err, ShouldBeNil)
+
+		Convey("Then a noop middleware is returned", func() {
+			So(reflect.TypeOf(middleware), ShouldEqual, reflect.TypeOf(&authorisation.NoopMiddleware{}))
+		})
+	})
+
+	Convey("When a config is supplied with the enable flag set to true and no permissions store", t, func() {
+		config := authorisation.Config{
+			Enabled:                        true,
+			PermissionsCacheUpdateInterval: time.Second * 60,
+			PermissionsMaxCacheTime:        time.Second * 60,
+		}
+		middleware, err := authorisation.NewFeatureFlaggedMiddlewareWithPermissionsStore(context.Background(), &config, map[string]string{}, nil)
+		So(middleware, ShouldBeNil)
+
+		Convey("Then the expected error is returned", func() {
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "permissions store cannot be nil")
+		})
+	})
+
+	Convey("When a config is supplied with the enable flag set to true and a permissions store", t, func() {
+		config := authorisation.Config{
+			Enabled:                        true,
+			PermissionsCacheUpdateInterval: time.Second * 60,
+			PermissionsMaxCacheTime:        time.Second * 60,
+		}
+		store := &permissionsMock.StoreMock{
+			GetPermissionsBundleFunc: func(ctx context.Context, headers permsdk.Headers) (permsdk.Bundle, error) {
+				return permsdk.Bundle{}, nil
+			},
+		}
+
+		middleware, err := authorisation.NewFeatureFlaggedMiddlewareWithPermissionsStore(context.Background(), &config, map[string]string{}, store)
+		So(err, ShouldBeNil)
+		defer func() {
+			So(middleware.Close(context.Background()), ShouldBeNil)
+		}()
+
+		Convey("Then a middleware from config is returned", func() {
+			So(reflect.TypeOf(middleware), ShouldEqual, reflect.TypeOf(&authorisation.PermissionCheckMiddleware{}))
+		})
+
+		Convey("Then the permissions store is used to populate the cache", func() {
+			So(store.GetPermissionsBundleCalls(), ShouldHaveLength, 1)
 		})
 	})
 }

--- a/identityclient/client_test.go
+++ b/identityclient/client_test.go
@@ -29,6 +29,7 @@ const (
 	jwtKeyRequestOK        = "jwt keys request ok"
 	healthErrorStatus      = "CRITICAL"
 	healthOKStatus         = "OK"
+	statusCodeKey          = "statusCode"
 	testJWTPublicKeyAPIMap = `{"test123=": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmwIDAQAB","test456=": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmwIDAQAB"}`
 )
 
@@ -59,7 +60,7 @@ func TestIndentityClient(t *testing.T) {
 					},
 				},
 				map[string]interface{}{
-					"statusCode": testStatusOK,
+					statusCodeKey: testStatusOK,
 				},
 			},
 			{
@@ -69,7 +70,7 @@ func TestIndentityClient(t *testing.T) {
 					},
 				},
 				map[string]interface{}{
-					"statusCode": nil,
+					statusCodeKey: nil,
 				},
 			},
 		}
@@ -78,7 +79,7 @@ func TestIndentityClient(t *testing.T) {
 			c.Client = tt.clientMock
 			r, _ := c.Get(ctx)
 			if r != nil {
-				So(r.StatusCode, ShouldEqual, tt.response["statusCode"])
+				So(r.StatusCode, ShouldEqual, tt.response[statusCodeKey])
 			}
 		}
 	})

--- a/permissions/checker_test.go
+++ b/permissions/checker_test.go
@@ -11,9 +11,19 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const (
+	adminGroupEntity       = "groups/admin"
+	publisherGroupEntity   = "groups/publisher"
+	checkerCollectionIDKey = "collection_id"
+	testCollectionID       = "collection765"
+	pathAttribute          = "path"
+	publisherGroup         = "publisher"
+	viewerGroup            = "viewer"
+)
+
 var permissionsBundle = permsdk.Bundle{
 	"users.add": map[string][]permsdk.Policy{
-		"groups/admin": {
+		adminGroupEntity: {
 			permsdk.Policy{
 				ID:        "policy1",
 				Condition: permsdk.Condition{},
@@ -21,13 +31,13 @@ var permissionsBundle = permsdk.Bundle{
 		},
 	},
 	"legacy.read": map[string][]permsdk.Policy{
-		"groups/admin": {
+		adminGroupEntity: {
 			permsdk.Policy{
 				ID:        "policy3",
 				Condition: permsdk.Condition{},
 			},
 		},
-		"groups/publisher": {
+		publisherGroupEntity: {
 			permsdk.Policy{
 				ID:        "policy4",
 				Condition: permsdk.Condition{},
@@ -37,21 +47,21 @@ var permissionsBundle = permsdk.Bundle{
 			permsdk.Policy{
 				ID: "policy2",
 				Condition: permsdk.Condition{
-					Attribute: "collection_id",
+					Attribute: checkerCollectionIDKey,
 					Operator:  permsdk.OperatorStringEquals,
-					Values:    []string{"collection765"},
+					Values:    []string{testCollectionID},
 				},
 			},
 		},
 	},
 	"legacy.write": map[string][]permsdk.Policy{
-		"groups/admin": {
+		adminGroupEntity: {
 			permsdk.Policy{
 				ID:        "policy5",
 				Condition: permsdk.Condition{},
 			},
 		},
-		"groups/publisher": {
+		publisherGroupEntity: {
 			permsdk.Policy{
 				ID:        "policy6",
 				Condition: permsdk.Condition{},
@@ -59,11 +69,11 @@ var permissionsBundle = permsdk.Bundle{
 		},
 	},
 	"some_service.write": map[string][]permsdk.Policy{
-		"groups/publisher": {
+		publisherGroupEntity: {
 			permsdk.Policy{
 				ID: "policy7",
 				Condition: permsdk.Condition{
-					Attribute: "path",
+					Attribute: pathAttribute,
 					Operator:  permsdk.OperatorStartsWith,
 					Values:    []string{"/files/dir/a/"},
 				},
@@ -103,7 +113,7 @@ func TestChecker_HasPermission_False(t *testing.T) {
 
 	Convey("Given a publisher user", t, func() {
 		entityData := permsdk.EntityData{
-			Groups: []string{"publisher"},
+			Groups: []string{publisherGroup},
 		}
 
 		Convey("When HasPermission is called for a permission a publisher does not have", func() {
@@ -151,11 +161,11 @@ func TestChecker_HasPermission_WithStringEqualsConditionTrue(t *testing.T) {
 
 	Convey("Given a viewer user", t, func() {
 		entityData := permsdk.EntityData{
-			Groups: []string{"viewer"},
+			Groups: []string{viewerGroup},
 		}
 
 		Convey("When HasPermission is called with a collection ID that satisfies the 'StringEquals' policy condition", func() {
-			attributes := map[string]string{"collection_id": "collection765"}
+			attributes := map[string]string{checkerCollectionIDKey: testCollectionID}
 
 			hasPermission, err := checker.HasPermission(ctx, entityData, "legacy.read", attributes)
 
@@ -177,11 +187,11 @@ func TestChecker_HasPermission_WithStringEqualsConditionFalse(t *testing.T) {
 
 	Convey("Given a viewer user", t, func() {
 		entityData := permsdk.EntityData{
-			Groups: []string{"viewer"},
+			Groups: []string{viewerGroup},
 		}
 
 		Convey("When HasPermission is called with a collection ID that does not satisfy a 'StringEquals' policy condition", func() {
-			attributes := map[string]string{"collection_id": "collection999"}
+			attributes := map[string]string{checkerCollectionIDKey: "collection999"}
 
 			hasPermission, err := checker.HasPermission(ctx, entityData, "legacy.read", attributes)
 
@@ -203,11 +213,11 @@ func TestChecker_HasPermission_WithCaseInsensitivePolicyConditionOperatorFalse(t
 
 	Convey("Given a viewer user", t, func() {
 		entityData := permsdk.EntityData{
-			Groups: []string{"viewer"},
+			Groups: []string{viewerGroup},
 		}
 
 		Convey("When HasPermission is called with a collection ID that satisfies an invalid (case-insensitive) 'stringequals' policy condition operator", func() {
-			attributes := map[string]string{"collection_id": "collection768"}
+			attributes := map[string]string{checkerCollectionIDKey: "collection768"}
 
 			hasPermission, err := checker.HasPermission(ctx, entityData, "legacy.read", attributes)
 
@@ -229,11 +239,11 @@ func TestChecker_HasPermission_WithStartsWithConditionTrue(t *testing.T) {
 
 	Convey("Given a publisher user", t, func() {
 		entityData := permsdk.EntityData{
-			Groups: []string{"publisher"},
+			Groups: []string{publisherGroup},
 		}
 
 		Convey("When HasPermission is called with a collection ID that satisfies the 'StartsWith' policy condition", func() {
-			attributes := map[string]string{"path": "/files/dir/a/some/dir/"}
+			attributes := map[string]string{pathAttribute: "/files/dir/a/some/dir/"}
 
 			hasPermission, err := checker.HasPermission(ctx, entityData, "some_service.write", attributes)
 
@@ -255,11 +265,11 @@ func TestChecker_HasPermission_WithStartsWithConditionFalse(t *testing.T) {
 
 	Convey("Given a publisher user", t, func() {
 		entityData := permsdk.EntityData{
-			Groups: []string{"publisher"},
+			Groups: []string{publisherGroup},
 		}
 
 		Convey("When HasPermission is called with a collection ID that does not satisfy the 'StartsWith' policy condition", func() {
-			attributes := map[string]string{"path": "/files/dir/c/some/dir/"}
+			attributes := map[string]string{pathAttribute: "/files/dir/c/some/dir/"}
 
 			hasPermission, err := checker.HasPermission(ctx, entityData, "some_service.write", attributes)
 
@@ -281,11 +291,11 @@ func TestChecker_HasPermission_MultipleConditionsChecked(t *testing.T) {
 
 	Convey("Given a viewer user", t, func() {
 		entityData := permsdk.EntityData{
-			Groups: []string{"viewer"},
+			Groups: []string{viewerGroup},
 		}
 
 		Convey("When HasPermission is called with a collection ID that satisfies the last 'StringEquals' policy condition", func() {
-			attributes := map[string]string{"collection_id": "collection765"}
+			attributes := map[string]string{checkerCollectionIDKey: testCollectionID}
 
 			hasPermission, err := checker.HasPermission(ctx, entityData, "legacy.read", attributes)
 


### PR DESCRIPTION
### What

- Allow authorisation middleware to use an injected permissions store
- Add store-backed middleware constructors so services can populate the permissions cache without calling the permissions API over HTTP. This keeps the existing config-based constructor behaviour unchanged while enabling callers such as dp-permissions-api to avoid loopback startup races.
- Add coverage for the new constructor path including disabled authorisation, nil store validation, and cache population through the injected store.


### How to review

Review the middleware.go and middleware_test.go files

### Who can review

!me
